### PR TITLE
feat: Added a filter section, displaying gen 1, can be filtered by types

### DIFF
--- a/src/Pages/Home/Home.tsx
+++ b/src/Pages/Home/Home.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from "react";
 import Hero from "../../components/Hero/Hero";
 import PokemonSection from "../../components/PokemonSection/PokemonSection";
 import type { PokemonData } from "../../data/pokemondata";
+import FilterPokemonSection from "../../components/FilterPokemonSection/FilterPokemonSection";
 
 
 const Home = () => {
@@ -20,6 +21,7 @@ const Home = () => {
         <>
         <Hero onFetch={setPokemon}/>
          {pokemon && <PokemonSection ref={sectionRef} data={pokemon} />}
+         <FilterPokemonSection />
         </>
     )
 }

--- a/src/components/FilterPokemonSection/FilterPokemonSection.styles.ts
+++ b/src/components/FilterPokemonSection/FilterPokemonSection.styles.ts
@@ -1,0 +1,13 @@
+import styled from "styled-components";
+
+export const FilterPokemon = styled.div`
+padding: ${({theme}) => theme.padding.normal};
+background-color:rgb(19, 0, 0);
+
+`
+
+export const FilterCheckboxes = styled.div`
+display:flex;
+justify-content: space-between;
+margin: ${({theme}) => theme.spacing.lg} 0
+`

--- a/src/components/FilterPokemonSection/FilterPokemonSection.tsx
+++ b/src/components/FilterPokemonSection/FilterPokemonSection.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from "react";
+import { FilterCheckboxes, FilterPokemon } from "./FilterPokemonSection.styles";
+
+const FilterPokemonSection = () => {
+
+    const TYPES = ["electric", "fire", "water", "grass", "flying", "bug", "psychic", "normal", "rock", "ground", "ghost", "poison"]; // lägg till fler vid behov
+    const [allPokemon, setAllPokemon] = useState<any[]>([]);
+    const [selectedTypes, setSelectedTypes] = useState<string[]>([]);
+
+    const handleTypeChange = (type: string) => {
+        setSelectedTypes((prev) =>
+            prev.includes(type) ? prev.filter((pokemonType) => pokemonType !== type) : [...prev, type]
+        );
+    };
+
+    //Function that renders the pokemon based on type selected, if no type is selected then all 151 is shown.
+    const getVisiblePokemon = () => {
+        if (selectedTypes.length === 0) return allPokemon;
+
+        return allPokemon.filter((pokemon) => {
+            const pokemonTypes = pokemon.types.map((pokemonType: any) => pokemonType.type.name);
+
+            return selectedTypes.every((type) => pokemonTypes.includes(type));
+        });
+    };
+
+    const resetValues = () => {
+        setSelectedTypes([]);
+    };
+
+
+    //For own reminder. This function gets ALL pokemon from gen 1, saves them with state.
+    const fetchAllPokemon = async () => {
+        try {
+            const response = await fetch("https://pokeapi.co/api/v2/pokemon?limit=151");
+            const data = await response.json();
+
+            //Gets the name of pokemon and image Url from API
+            const pokemonDetails = await Promise.all(
+                data.results.map(async (pokemon: { name: string, url: string }) => {
+                    const res = await fetch(pokemon.url);
+                    return await res.json();
+                })
+            );
+
+            setAllPokemon(pokemonDetails)
+
+        } catch (err) {
+            console.log(err, "Something went wrong");
+        }
+    }
+
+    //When page render it makes sure to fetch all 151 pokemon from gen 1
+    useEffect(() => {
+        fetchAllPokemon();
+    }, [])
+
+    return (
+        <FilterPokemon>
+            <p>Filter Pokémon by selecting the filter tags</p>
+            <button onClick={resetValues}>Reset Filters</button>
+            <FilterCheckboxes>
+                {TYPES.map((type) => (
+                    <label key={type}>
+                        <input
+                            type="checkbox"
+                            value={type}
+                            checked={selectedTypes.includes(type)}
+                            onChange={() => handleTypeChange(type)}
+                        />
+                        {type}
+                    </label>
+                ))}
+            </FilterCheckboxes>
+
+            <div>
+                {getVisiblePokemon().map((pokemon, index) => (
+                    <img
+                        key={index}
+                        src={pokemon.sprites.front_default}
+                        alt={pokemon.name}
+                    />
+                ))}
+            </div>
+        </FilterPokemon>
+    )
+}
+
+export default FilterPokemonSection;

--- a/src/components/GradientTitle/GradientTitle.styles.ts
+++ b/src/components/GradientTitle/GradientTitle.styles.ts
@@ -8,4 +8,11 @@ export const StyledTitle = styled.h2`
     font-size: ${({theme}) => theme.fontSizes.xxl};
     line-height: 1.2;
 
+    @media (max-width: ${({theme}) => theme.breakpoints.desktop}) {
+        font-size: ${({theme}) => theme.fontSizes.xl}
+    }
+
+     @media (max-width: ${({theme}) => theme.breakpoints.mobile}) {
+        font-size: ${({theme}) => theme.fontSizes.lg}
+    }
 `

--- a/src/components/Hero/Hero.styles.ts
+++ b/src/components/Hero/Hero.styles.ts
@@ -6,10 +6,21 @@ flex-direction: row;
 justify-content: space-between;
 margin: auto;
 align-items: center;
-background: ${({theme}) => theme.colors.heroBackground};
-padding: ${({theme}) => theme.padding.normal};
-gap: ${({theme}) => theme.spacing.lg};
+background: ${({ theme }) => theme.colors.heroBackground};
+padding: ${({ theme }) => theme.padding.normal};
+gap: ${({ theme }) => theme.spacing.lg};
 min-height: 90vh;
+
+@media (max-width:${({ theme }) => theme.breakpoints.tablet}) {
+    flex-direction: column-reverse;
+}
+
+@media (max-width: ${({ theme }) => theme.breakpoints.mobile}) {
+    img {
+    max-width: 300px;
+    }
+}
+
 
 div {
 flex: 1
@@ -28,24 +39,25 @@ img {
 }
 
 p {
-    font-size: ${({theme}) => theme.fontSizes.md};
+    font-size: ${({ theme }) => theme.fontSizes.md};
     font-weight: 650;
     line-height: 32px
 }
 
 h3 {
-    font-size: ${({theme}) => theme.fontSizes.md};
-    color: ${({theme}) => theme.colors.subtitleColor};
+    font-size: ${({ theme }) => theme.fontSizes.md};
+    color: ${({ theme }) => theme.colors.subtitleColor};
 }
 `
 
 export const InputButtonDiv = styled.div`
 display: flex;
-gap: ${({theme}) => theme.spacing.xs};
+gap: ${({ theme }) => theme.spacing.xs};
 `
 
 export const Vertical16Gap = styled.div`
 display:flex;
 flex-direction: column;
-gap: ${({theme}) => theme.spacing.md};
+gap: ${({ theme }) => theme.spacing.md};
 `
+

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -26,6 +26,11 @@ export const theme = {
     },
     padding: {
         normal: "4rem 6rem",
+    },
+    breakpoints: {
+      mobile: "490px",
+      tablet: "990px",
+      desktop: "1220px",
     }
 }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0f1dfc73-f27a-4ee8-9029-2e6b7c03bdfd)
Added a way to filter search for pokemon from Pokémon gen 1

example1: filter by fire: 
![image](https://github.com/user-attachments/assets/c46699ef-1e4a-4fd0-9658-b7b58900c0fa)


example2: filter by grass and poison: 
![image](https://github.com/user-attachments/assets/ecd07b64-202e-4718-8803-2ec571a2013c)
